### PR TITLE
Fix missing models package

### DIFF
--- a/internal/paths/models/keypath.go
+++ b/internal/paths/models/keypath.go
@@ -1,0 +1,35 @@
+package models
+
+import "strings"
+
+type FlattenKeypath string
+
+func (kp FlattenKeypath) Terms() []string {
+	if kp == "" {
+		return []string{}
+	}
+	return strings.Split(string(kp), ".")
+}
+
+func (kp FlattenKeypath) Termination() string {
+	terms := kp.Terms()
+	if len(terms) == 0 {
+		return ""
+	}
+	return terms[len(terms)-1]
+}
+
+func (kp FlattenKeypath) Parent() FlattenKeypath {
+	terms := kp.Terms()
+	if len(terms) <= 1 {
+		return ""
+	}
+	return FlattenKeypath(strings.Join(terms[:len(terms)-1], "."))
+}
+
+func (kp FlattenKeypath) Sub(term string) FlattenKeypath {
+	if kp == "" {
+		return FlattenKeypath(term)
+	}
+	return FlattenKeypath(string(kp) + "." + term)
+}

--- a/internal/types/organizer/organizer_test.go
+++ b/internal/types/organizer/organizer_test.go
@@ -7,7 +7,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/ufukty/gonfique/internal/coder"
+	"github.com/ufukty/gonfique/internal/files/coder"
 	"github.com/ufukty/gonfique/internal/files/input"
 	"github.com/ufukty/gonfique/internal/testutils"
 	"github.com/ufukty/gonfique/internal/transform"


### PR DESCRIPTION
## Summary
- add `internal/paths/models` with `FlattenKeypath` type
- correct organizer test import path

## Testing
- `go build ./cmd/gonfique`
- `go test ./...` *(fails: gopkg.in/yaml.v3 download forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_684ad177a8ac8324ad7a45d1181d5d96